### PR TITLE
Added: a thin wrapper around the Net::HTTP 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,7 @@ group :development do
   gem "rubocop-minitest", "~> 0.11"
   gem "rubocop-rake", "~> 0.5"
 end
+
+group :test do
+  gem "webmock"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,11 +6,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    crack (0.4.5)
+      rexml
+    hashdiff (1.0.1)
     minitest (5.14.4)
     parallel (1.20.1)
     parser (3.0.1.0)
       ast (~> 2.4.1)
+    public_suffix (4.0.6)
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.1.1)
@@ -32,6 +38,10 @@ GEM
       rubocop
     ruby-progressbar (1.11.0)
     unicode-display_width (2.0.0)
+    webmock (3.12.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   arm64-darwin-20
@@ -44,6 +54,7 @@ DEPENDENCIES
   rubocop-minitest (~> 0.11)
   rubocop-rake (~> 0.5)
   solaredge-ruby!
+  webmock
 
 RUBY VERSION
    ruby 3.0.1p64

--- a/lib/solaredge.rb
+++ b/lib/solaredge.rb
@@ -3,6 +3,7 @@
 require_relative "solaredge/version"
 require_relative "solaredge/error"
 require_relative "solaredge/configuration"
+require_relative "solaredge/http_client"
 
 module Solaredge
 end

--- a/lib/solaredge/configuration.rb
+++ b/lib/solaredge/configuration.rb
@@ -6,24 +6,8 @@ module Solaredge
     # @return [String] The API key for accessing the Solaredge API
     attr_accessor :api_key
 
-    # The `response_format` enables API consumers to define a custom response format.
-    # @return [Symbol] The response format for the API response.
-    AVAILABLE_RESPONSE_FORMATS = %i[json xml csv].freeze
-    attr_reader :response_format
-
     def initialize
       @api_key = ""
-      @response_format = :json
-    end
-
-    # The `response_format=` allows overwriting the response format for all API calls.
-    # @param format [String, Symbol] The new response format
-    # @return [Symbol] The response format
-    def response_format=(format)
-      new_response_format = format.downcase.to_sym
-      raise InvalidResponseFormat, new_response_format unless AVAILABLE_RESPONSE_FORMATS.include?(new_response_format)
-
-      @response_format = new_response_format
     end
   end
 

--- a/lib/solaredge/error.rb
+++ b/lib/solaredge/error.rb
@@ -23,17 +23,6 @@ module Solaredge
     end
   end
 
-  # The `InvalidResponseFormat` is raised whenever the API consumer requested
-  # a response format which is different from the available response formats.
-  class InvalidResponseFormat < Error
-    def initialize(response_format)
-      super(
-        "[Solaredge] '#{response_format}' is not a valid response format. " \
-          "Please use one of the available response formats (e.g. json, xml or csv)."
-      )
-    end
-  end
-
   # The `MissingApiKey` is raised whenever the API consumer forgot to add the API key.
   class MissingApiKey < Error
     def initialize

--- a/lib/solaredge/error.rb
+++ b/lib/solaredge/error.rb
@@ -8,10 +8,18 @@ module Solaredge
   class BadConfiguration < Error
     def initialize
       super(
-        "The provided configuration object is not a Solaredge::Configuration " \
-          "instance. Please provide a Solaredge::Configuration instance when "  \
-          "overriding the configuration directly."
+        "[Solaredge] The provided configuration object is not a " \
+          "Solaredge::Configuration instance. Please provide a "  \
+          "Solaredge::Configuration instance when overriding the configuration directly."
       )
+    end
+  end
+
+  # The `Solaredge::HttpClientError` is raised whenever the Solaredge API
+  # returns a status code other than success.
+  class HttpClientError < Error
+    def initialize(code:, message:)
+      super("[Solaredge] #{message}  - #{code}")
     end
   end
 
@@ -20,8 +28,18 @@ module Solaredge
   class InvalidResponseFormat < Error
     def initialize(response_format)
       super(
-        "'#{response_format}' is not a valid response format. " \
+        "[Solaredge] '#{response_format}' is not a valid response format. " \
           "Please use one of the available response formats (e.g. json, xml or csv)."
+      )
+    end
+  end
+
+  # The `MissingApiKey` is raised whenever the API consumer forgot to add the API key.
+  class MissingApiKey < Error
+    def initialize
+      super(
+        "[Solaredge] Missing API key: Please, provide an API key to make requests " \
+          "to the Solaredge Monitoring API."
       )
     end
   end

--- a/lib/solaredge/http_client.rb
+++ b/lib/solaredge/http_client.rb
@@ -41,9 +41,8 @@ module Solaredge
 
     def build_resource_url(path, params = {})
       api_key = Solaredge.config.api_key
-      response_format = Solaredge.config.response_format
 
-      URI("#{api_endpoint}/#{path}.#{response_format}").tap do |url|
+      URI("#{api_endpoint}/#{path}.json").tap do |url|
         url.query = URI.encode_www_form(params.merge(api_key: api_key))
       end
     end

--- a/lib/solaredge/http_client.rb
+++ b/lib/solaredge/http_client.rb
@@ -19,7 +19,7 @@ module Solaredge
     # @param path [String] The path to the requested resource
     # @param params [Hash] A hash with additional parameters for the requested resource.
     # @return [String] the response from the API
-    def request(path:, params: {})
+    def request(path, params: {})
       raise MissingApiKey if Solaredge.config.api_key.empty?
 
       # Build the full resource url based on the given path and the optional params.

--- a/lib/solaredge/http_client.rb
+++ b/lib/solaredge/http_client.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+
+module Solaredge
+  # The `HttpClient` is a thin wrapper around the Net::HTTP::GET class with
+  # some sensible defaults for the interaction with the Solaredge API.
+  class HttpClient
+    SOLAREDGE_API_ENDPOINT = "https://monitoringapi.solaredge.com"
+
+    attr_reader :api_endpoint
+
+    def initialize
+      @api_endpoint = SOLAREDGE_API_ENDPOINT
+    end
+
+    # The `request` performs an HTTP GET request to the given path.
+    # @param path [String] The path to the requested resource
+    # @param params [Hash] A hash with additional parameters for the requested resource.
+    # @return [String] the response from the API
+    def request(path:, params: {})
+      raise MissingApiKey if Solaredge.config.api_key.empty?
+
+      # Build the full resource url based on the given path and the optional params.
+      resource_url = build_resource_url(path, params)
+
+      # Perform the HTTP request and return the response body.
+      response = Net::HTTP.get_response(resource_url)
+      response_body = JSON.parse(response.body)
+
+      unless response.is_a?(Net::HTTPSuccess)
+        raise HttpClientError.new(code: response.code, message: response_body["String"])
+      end
+
+      # Return the response body so it can be parsed by the `Solaredge::Resource`.
+      response_body
+    end
+
+    private
+
+    def build_resource_url(path, params = {})
+      api_key = Solaredge.config.api_key
+      response_format = Solaredge.config.response_format
+
+      URI("#{api_endpoint}/#{path}.#{response_format}").tap do |url|
+        url.query = URI.encode_www_form(params.merge(api_key: api_key))
+      end
+    end
+  end
+
+  # Returns the `Solaredge::HttpClient` to interact with the Solaredege monitoring API.
+  # @return [Solaredge::HttpClient] The `Solaredge::HttpClient`
+  def self.client
+    @client ||= HttpClient.new
+  end
+end

--- a/test/solaredge/configuration_test.rb
+++ b/test/solaredge/configuration_test.rb
@@ -19,15 +19,4 @@ describe Solaredge::Configuration do
       error_message.to_s
     )
   end
-
-  private
-
-  # Allows temporary setting a configuration option during tests. Switches back
-  # to the original configuration after running the test.
-  def with_temp_config(&block)
-    previous_config = Solaredge.config
-    Solaredge.configure { |config| block.call(config) }
-  ensure
-    Solaredge.config = previous_config
-  end
 end

--- a/test/solaredge/configuration_test.rb
+++ b/test/solaredge/configuration_test.rb
@@ -3,10 +3,6 @@
 require "test_helper"
 
 describe Solaredge::Configuration do
-  it "sets the response format to json by default" do
-    assert_equal :json, Solaredge::Configuration.new.response_format
-  end
-
   it "sets the api key to an empty string by default" do
     assert_equal "", Solaredge::Configuration.new.api_key
   end
@@ -17,41 +13,11 @@ describe Solaredge::Configuration do
     end
 
     assert_equal(
-      "The provided configuration object is not a Solaredge::Configuration " \
+      "[Solaredge] The provided configuration object is not a Solaredge::Configuration " \
         "instance. Please provide a Solaredge::Configuration instance when "  \
         "overriding the configuration directly.",
       error_message.to_s
     )
-  end
-
-  describe "configuring the response format" do
-    it "configures the response format" do
-      with_temp_config do |config|
-        config.response_format = :xml
-        assert_equal :xml, config.response_format
-      end
-    end
-
-    it "configures the response format when it's an upcased string" do
-      with_temp_config do |config|
-        config.response_format = "JSON"
-        assert_equal :json, config.response_format
-      end
-    end
-
-    it "raises when the response format is invalid" do
-      with_temp_config do |config|
-        error_message = assert_raises Solaredge::InvalidResponseFormat do
-          config.response_format = :jsonp
-        end
-
-        assert_equal(
-          "'jsonp' is not a valid response format. " \
-            "Please use one of the available response formats (e.g. json, xml or csv).",
-          error_message.to_s
-        )
-      end
-    end
   end
 
   private

--- a/test/solaredge/http_client_test.rb
+++ b/test/solaredge/http_client_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Solaredge::HttpClient do
+  before do
+    @fake_api_key = "kz1a6ZKJ31T4jwF9prTjt5OVDYhmHl"
+  end
+
+  it "performs a request to the expected endpoint" do
+    stub_request(:get, "https://monitoringapi.solaredge.com/sites/list.json?api_key=#{@fake_api_key}")
+      .and_return(status: 200, body: {}.to_json)
+
+    with_solaredge_config do |c|
+      c.api_key = @fake_api_key
+
+      assert Solaredge.client.request("sites/list")
+    end
+  end
+
+  it "adds additional parameters to the request" do
+    stub_request(:get, "https://monitoringapi.solaredge.com/sites/list.json?size=10&api_key=#{@fake_api_key}")
+      .and_return(status: 200, body: {}.to_json)
+
+    with_solaredge_config do |c|
+      c.api_key = @fake_api_key
+
+      assert Solaredge.client.request("sites/list", params: { size: 10 })
+    end
+  end
+
+  it "raises Solaredge::MissingApiKey when the API key is not configured" do
+    with_solaredge_config do |c|
+      c.api_key = ""
+
+      assert_raises Solaredge::MissingApiKey do
+        Solaredge.client.request("sites/list")
+      end
+    end
+  end
+
+  it "raises Solaredge::HttpClientError when the API returns a not OK status" do
+    stub_request(:get, "https://monitoringapi.solaredge.com/sites/list.json?size=10&api_key=#{@fake_api_key}")
+      .and_return(status: 429, body: { String: "too many requests" }.to_json)
+
+    with_solaredge_config do |c|
+      c.api_key = @fake_api_key
+
+      assert Solaredge::HttpClientError do
+        Solaredge.client.request("sites/list")
+      end
+    end
+  end
+end

--- a/test/support/configuration_helper.rb
+++ b/test/support/configuration_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Allows temporary setting a configuration option during tests. Switches back
+# to the original configuration after running the test.
+def with_solaredge_config(&block)
+  previous_config = Solaredge.config
+  Solaredge.configure { |config| block.call(config) }
+ensure
+  Solaredge.config = previous_config
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,6 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "solaredge"
 
 require "minitest/autorun"
+
+# Require additional helpers for the tests
+require "support/configuration_helper"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "solaredge"
 
 require "minitest/autorun"
+require "webmock/minitest"
 
 # Require additional helpers for the tests
 require "support/configuration_helper"


### PR DESCRIPTION
Adds a thin wrapper around the default Net::HTTP class for interacting with the Solaredge Monitoring API.